### PR TITLE
update provisioners to work in December 2025

### DIFF
--- a/provisioners/install-mongo.sh
+++ b/provisioners/install-mongo.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
 #get GPG key
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | \
+   sudo gpg -o /usr/share/keyrings/mongodb-server-4.4.gpg \
+   --dearmor
 #create a sources list file
-echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-4.4.gpg ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
 #reload package database
 sudo apt-get update
 #install Mongo
 sudo apt-get install -y mongodb-org
 #start mongo
-systemctl enable mongod.service
-sudo service mongod start
+sudo systemctl enable mongod
+sudo systemctl start mongod

--- a/provisioners/install-node.sh
+++ b/provisioners/install-node.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
 
-#nodesource PPA
-curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
-#update package database
+# Define the desired Node.js major version
+NODE_MAJOR=16
+# Update local package index
 sudo apt-get update
-#install NodeJS
+# Install necessary packages for downloading and verifying new repository information
+sudo apt-get install -y ca-certificates curl gnupg
+# Create a directory for the new repository's keyring, if it doesn't exist
+sudo mkdir -p /etc/apt/keyrings
+# Download the new repository's GPG key and save it in the keyring directory
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+# Add the new repository's source list with its GPG key for package verification
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+# Update local package index to recognize the new repository
+sudo apt-get update
+# Install Node.js from the new repository
 sudo apt-get install -y nodejs
+
+
+
 #install PM2 to support NodeJS application run-as-service
 sudo npm install -g pm2
 #start TodoList app as a service


### PR DESCRIPTION
The current provisioners are broken due to changes in ubuntu, node and mongo repositories.
This change updates both provisioners to use the latest versions compatible with Ubuntu 16.04.
Tested with Ubuntu 16.04.7 LTS.